### PR TITLE
implement the adapter API for assert-activerecord adapter gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ ruby '> 1.8'
 gemspec
 
 gem "pry", "~> 0.11.3"
+
+gem "assert-activerecord", :github => "redding/assert-activerecord"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ AssertActiveRecord adapter for ActiveRecord 4.  See https://github.com/redding/a
 
 ## Usage
 
-TODO: Write code samples and usage instructions here
+### Reset the test db for test runs
+
+```ruby
+# in test/helper.rb
+require "assert-activerecord4"
+AssertActiveRecord.reset_db
+```
+
+TODO: transactional DbTests
 
 ## Installation
 

--- a/assert-activerecord4.gemspec
+++ b/assert-activerecord4.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.17.0"])
 
-  gem.add_dependency("activerecord", ["~> 4.0"])
+  gem.add_dependency("activerecord",        ["~> 4.0"])
+  gem.add_dependency("assert-activerecord", ["~> 0.0.1"])
 
 end

--- a/lib/assert-activerecord4.rb
+++ b/lib/assert-activerecord4.rb
@@ -1,4 +1,9 @@
+require "assert-activerecord"
+
 require "assert-activerecord4/version"
+require "assert-activerecord4/adapter"
 
 module AssertActiveRecord4
 end
+
+AssertActiveRecord.adapter(AssertActiveRecord4::Adapter.new)

--- a/lib/assert-activerecord4/adapter.rb
+++ b/lib/assert-activerecord4/adapter.rb
@@ -1,0 +1,37 @@
+require "active_record"
+require "active_record/tasks/database_tasks"
+require "assert-activerecord/adapter"
+
+module AssertActiveRecord4
+
+  class Adapter
+    include AssertActiveRecord::Adapter
+
+    def self.database_tasks
+      ActiveRecord::Tasks::DatabaseTasks
+    end
+
+    def drop_db
+      self.class.database_tasks.drop_current(self.test_env_name)
+    end
+
+    def create_db
+      self.class.database_tasks.create_current(self.test_env_name)
+    end
+
+    def load_schema
+      # ActiveRecord::Base.schema_format can either be `:ruby` or `:sql`
+      self.class.database_tasks.load_schema(
+        ActiveRecord::Base.schema_format,
+        ENV["SCHEMA"],
+        self.test_env_name
+      )
+    end
+
+    def connect_db
+      ActiveRecord::Base.establish_connection(self.test_env_name)
+    end
+
+  end
+
+end

--- a/test/unit/adapter_tests.rb
+++ b/test/unit/adapter_tests.rb
@@ -1,0 +1,131 @@
+require "assert"
+require "assert-activerecord4/adapter"
+
+require "active_record"
+require "active_record/tasks/database_tasks"
+
+class AssertActiveRecord4::Adapter
+
+  class UnitTests < Assert::Context
+    desc "AssertActiveRecord4::Adapter"
+    setup do
+      @class = AssertActiveRecord4::Adapter
+    end
+    subject{ @class }
+
+    should "mixin AssertActiveRecord::Adapter" do
+      assert_includes AssertActiveRecord::Adapter, subject
+    end
+
+    should have_imeths :database_tasks
+
+    should "know its database tasks" do
+      assert_equal ActiveRecord::Tasks::DatabaseTasks, subject.database_tasks
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @tasks_spy = TasksSpy.new
+      Assert.stub(@class, :database_tasks){ @tasks_spy }
+
+      @establish_connection_called_with = nil
+      Assert.stub(ActiveRecord::Base, :establish_connection) do |*args|
+        @establish_connection_called_with = args
+      end
+
+      @orig_schema_value = ENV["SCHEMA"]
+      ENV["SCHEMA"] = Factory.path
+
+      @adapter = @class.new
+    end
+    teardown do
+      ENV["SCHEMA"] = @orig_schema_value
+    end
+    subject{ @adapter }
+
+    should have_imeths :drop_db, :create_db, :load_schema, :connect_db
+
+    should "be able to drop a db" do
+      assert_equal 0, @tasks_spy.drop_current_called_count
+
+      subject.drop_db
+      assert_equal 1, @tasks_spy.drop_current_called_count
+
+      exp = [subject.test_env_name]
+      assert_equal exp, @tasks_spy.drop_current_called_withs.first
+    end
+
+    should "know how to create a db" do
+      assert_equal 0, @tasks_spy.create_current_called_count
+
+      subject.create_db
+      assert_equal 1, @tasks_spy.create_current_called_count
+
+      exp = [subject.test_env_name]
+      assert_equal exp, @tasks_spy.create_current_called_withs.first
+    end
+
+    should "know how to load a schema" do
+      assert_equal 0, @tasks_spy.load_schema_called_count
+
+      subject.load_schema
+      assert_equal 1, @tasks_spy.load_schema_called_count
+
+      exp = [
+        ActiveRecord::Base.schema_format,
+        ENV["SCHEMA"],
+        subject.test_env_name
+      ]
+      assert_equal exp, @tasks_spy.load_schema_called_withs.first
+    end
+
+    should "know how to connect to a db" do
+      subject.connect_db
+
+      exp = [subject.test_env_name]
+      assert_equal exp, @establish_connection_called_with
+    end
+
+  end
+
+  class TasksSpy
+
+    attr_reader :drop_current_called_withs, :create_current_called_withs
+    attr_reader :load_schema_called_withs
+
+    def initialize
+      @drop_current_called_withs   = []
+      @create_current_called_withs = []
+      @load_schema_called_withs    = []
+    end
+
+    def drop_current_called_count
+      self.drop_current_called_withs.size
+    end
+
+    def create_current_called_count
+      self.create_current_called_withs.size
+    end
+
+    def load_schema_called_count
+      self.load_schema_called_withs.size
+    end
+
+    def drop_current(*args)
+      self.drop_current_called_withs << args
+    end
+
+    def create_current(*args)
+      self.create_current_called_withs << args
+    end
+
+    def load_schema(*args)
+      self.load_schema_called_withs << args
+    end
+
+  end
+
+end

--- a/test/unit/assert-activerecord4_tests.rb
+++ b/test/unit/assert-activerecord4_tests.rb
@@ -1,0 +1,22 @@
+require "assert"
+require "assert-activerecord4"
+
+require "assert-activerecord4/adapter"
+
+module AssertActiveRecord4
+
+  class UnitTests < Assert::Context
+    desc "AssertActiveRecord4"
+    setup do
+      @module = AssertActiveRecord4
+    end
+    subject{ @module }
+
+    should "set AssetActiveRecord's adapter" do
+      exp = AssertActiveRecord4::Adapter
+      assert_instance_of exp, AssertActiveRecord.adapter
+    end
+
+  end
+
+end


### PR DESCRIPTION
This allows keeping the framework code in the assert-activerecord
gem and roll adapter gems for logic that is specific to each major
version of ActiveRecord.

This includes the adapter logic and tests, plus a README write up.

This also temporarily points the Gemfile at a dev feature branch
of AssertActiveRecord so CI will run.

@jcredding ready for review.