### PR TITLE
implement the DbTests adapter API methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,30 @@ require "assert-activerecord4"
 AssertActiveRecord.reset_db
 ```
 
-TODO: transactional DbTests
+### Running database tests in a transaction
+
+```ruby
+# in test/helper.rb
+require "assert-activerecord4"
+class DbTests < AssertActiveRecord::DbTests
+  # put any extra setup / teardown logic here
+end
+```
+
+Then in a test that needs to interact with the database:
+
+```ruby
+require "assert"
+require "blog_record"
+
+class BlogRecord
+
+  class SystemTests < DbTests
+    # all tests in this context will be run in a transaction
+  end
+
+end
+```
 
 ## Installation
 

--- a/lib/assert-activerecord4/adapter.rb
+++ b/lib/assert-activerecord4/adapter.rb
@@ -32,6 +32,14 @@ module AssertActiveRecord4
       ActiveRecord::Base.establish_connection(self.test_env_name)
     end
 
+    def transaction(&block)
+      ActiveRecord::Base.transaction(&block)
+    end
+
+    def rollback!
+      raise ActiveRecord::Rollback
+    end
+
   end
 
 end

--- a/test/unit/db_tests_tests.rb
+++ b/test/unit/db_tests_tests.rb
@@ -1,0 +1,38 @@
+require "assert"
+require "assert-activerecord/db_tests"
+
+# Note: this is "unit" test that is acting like a "system-ish" test between
+# this adapter gem and AssertActiveRecord's DbTests.  It is a copy of the
+# same unit tests in AssertActiveRecord but instead of stubbing the adapter,
+# it stubs ActiveRecord directly.
+
+class AssertActiveRecord::DbTests
+
+  class UnitTests < Assert::Context
+    desc "AssertActiveRecord::DbTests"
+    setup do
+      @transaction_called = false
+      Assert.stub(ActiveRecord::Base, :transaction) do |&block|
+        @transaction_called = true
+        block.call
+      end
+
+      @class = AssertActiveRecord::DbTests
+    end
+    subject{ @class }
+
+    should "add an around callback to run tests in a rollback transaction" do
+      assert_equal 1, subject.arounds.size
+      callback = subject.arounds.first
+
+      block_yielded_to = false
+      assert_raises(ActiveRecord::Rollback) do
+        callback.call(proc{ block_yielded_to = true })
+      end
+      assert_true @transaction_called
+      assert_true block_yielded_to
+    end
+
+  end
+
+end


### PR DESCRIPTION
This enables running database tests in a transaction and rolling
back after the tests run.

This implements the adapter methods and adds a system-ish test for
AssertActiveRecord:DbTests stubbing ActiveRecord directly.

This also adds a README writeup on using DbTests since all usage
docs live in the adapter gems.

@jcredding ready for review.